### PR TITLE
Reemplazo de filtros utilizando select por custom component multiselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tooltip": "^1.0.7",

--- a/src/app/(home)/page.client.tsx
+++ b/src/app/(home)/page.client.tsx
@@ -18,6 +18,7 @@ import {Checkbox} from "@/components/ui/checkbox";
 import {Label} from "@/components/ui/label";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip";
 import {cn} from "@/lib/utils";
+import {MultiSelect, MultiSelectOption} from "@/components/ui/multiSelect";
 
 export default function HomePageClient({
   salaries,
@@ -36,26 +37,26 @@ export default function HomePageClient({
   const [filters, setFilters] = useReducer(
     (
       state: {
-        currency: string;
-        seniority: string;
-        position: string;
+        currencyFilter: Array<string>;
+        seniorityFilter: Array<string>;
+        positionFilter: Array<string>;
         simulate: boolean;
         order: keyof Salary;
         ascending: boolean;
       },
       newState: Partial<{
-        currency: string;
-        seniority: string;
-        position: string;
+        currencyFilter: Array<string>;
+        seniorityFilter: Array<string>;
+        positionFilter: Array<string>;
         simulate: boolean;
         order: keyof Salary;
         ascending: boolean;
       }>,
     ) => ({...state, ...newState}),
     {
-      currency: "",
-      seniority: "",
-      position: "",
+      currencyFilter: [],
+      seniorityFilter: [],
+      positionFilter: [],
       simulate: false,
       order: "title",
       ascending: true,
@@ -66,9 +67,9 @@ export default function HomePageClient({
       [...salaries]
         .filter(
           ({currency, seniority, title}) =>
-            (!filters.currency || currency === filters.currency) &&
-            (!filters.seniority || seniority === filters.seniority) &&
-            (!filters.position || title === filters.position),
+          (!Boolean(filters.currencyFilter.length) || filters.currencyFilter.includes(currency)) &&
+          (!Boolean(filters.seniorityFilter.length) || filters.seniorityFilter.includes(seniority)) &&
+          (!Boolean(filters.positionFilter.length) || filters.positionFilter.includes(title)),
         )
         .sort((a, b) => {
           // Filter by currency
@@ -114,36 +115,57 @@ export default function HomePageClient({
     <section className="grid gap-4">
       <nav className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={filters.position}
-            onChange={(e) => setFilters({position: e.target.value})}
-          >
-            <option value="">Todas las posiciones</option>
+          <MultiSelect title="Posiciones">
             {positions.map((position) => (
-              <option key={position}>{position}</option>
+              <MultiSelectOption
+                key={position}
+                checked={filters.positionFilter.includes(position)}
+                onCheckedChange={() => {
+                  if (!filters.positionFilter.includes(position)) {
+                    setFilters({positionFilter: [...filters.positionFilter, position]})
+                  } else {
+                    setFilters({positionFilter: filters.positionFilter.filter(pos => pos !== position)})
+                  }
+                }}
+              >
+                {position}
+              </MultiSelectOption>
             ))}
-          </select>
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={filters.currency}
-            onChange={(e) => setFilters({currency: e.target.value})}
-          >
-            <option value="">Todas las monedas</option>
+          </MultiSelect>
+          <MultiSelect title="Moneda">
             {currencies.map((currency) => (
-              <option key={currency}>{currency}</option>
+              <MultiSelectOption
+                key={currency}
+                checked={filters.currencyFilter.includes(currency)}
+                onCheckedChange={() => {
+                  if (!filters.currencyFilter.includes(currency)) {
+                    setFilters({currencyFilter: [...filters.currencyFilter, currency]})
+                  } else {
+                    setFilters({currencyFilter: filters.currencyFilter.filter(curr => curr !== currency)})
+                  }
+                }}
+              >
+                {currency}
+              </MultiSelectOption>
             ))}
-          </select>
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={filters.seniority}
-            onChange={(e) => setFilters({seniority: e.target.value})}
-          >
-            <option value="">Todos los seniorities</option>
-            {seniorities.map((seniority) => (
-              <option key={seniority}>{seniority}</option>
+          </MultiSelect>
+          <MultiSelect title="Seniority">
+             {seniorities.map((seniority) => (
+              <MultiSelectOption
+                key={seniority}
+                checked={filters.seniorityFilter.includes(seniority)}
+                onCheckedChange={() => {
+                  if (!filters.seniorityFilter.includes(seniority)) {
+                    setFilters({seniorityFilter: [...filters.seniorityFilter, seniority]})
+                  } else {
+                    setFilters({seniorityFilter: filters.seniorityFilter.filter(sen => sen !== seniority)})
+                  }
+                }}
+              >
+                {seniority}
+              </MultiSelectOption>
             ))}
-          </select>
+          </MultiSelect>
         </div>
         {originalDollarPrice !== dollarPrice && (
           <Label className="flex items-center gap-2" htmlFor="simulate">

--- a/src/app/(home)/page.client.tsx
+++ b/src/app/(home)/page.client.tsx
@@ -17,6 +17,7 @@ import {
 import {Checkbox} from "@/components/ui/checkbox";
 import {Label} from "@/components/ui/label";
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@/components/ui/tooltip";
+import {MultiSelect, MultiSelectOption} from "@/components/ui/multiSelect";
 
 export default function HomePageClient({
   salaries,
@@ -35,22 +36,22 @@ export default function HomePageClient({
   const [formData, setFormData] = useReducer(
     (
       state: {
-        currency: string;
-        seniority: string;
-        position: string;
+        currencyFilter: Array<string>;
+        seniorityFilter: Array<string>;
+        positionFilter: Array<string>;
         simulate: boolean;
       },
       newState: Partial<{
-        currency: string;
-        seniority: string;
-        position: string;
+        currencyFilter: Array<string>;
+        seniorityFilter: Array<string>;
+        positionFilter: Array<string>;
         simulate: boolean;
       }>,
     ) => ({...state, ...newState}),
     {
-      currency: "",
-      seniority: "",
-      position: "",
+      currencyFilter: [],
+      seniorityFilter: [],
+      positionFilter: [],
       simulate: false,
     },
   );
@@ -58,9 +59,9 @@ export default function HomePageClient({
     () =>
       salaries.filter(
         ({currency, seniority, title}) =>
-          (!formData.currency || currency === formData.currency) &&
-          (!formData.seniority || seniority === formData.seniority) &&
-          (!formData.position || title === formData.position),
+          (!Boolean(formData.currencyFilter.length) || formData.currencyFilter.includes(currency)) &&
+          (!Boolean(formData.seniorityFilter.length) || formData.seniorityFilter.includes(seniority)) &&
+          (!Boolean(formData.positionFilter.length) || formData.positionFilter.includes(title)),
       ),
     [formData, salaries],
   );
@@ -69,36 +70,57 @@ export default function HomePageClient({
     <section className="grid gap-4">
       <nav className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={formData.position}
-            onChange={(e) => setFormData({position: e.target.value})}
-          >
-            <option value="">Todas las posiciones</option>
+          <MultiSelect title="Posiciones">
             {positions.map((position) => (
-              <option key={position}>{position}</option>
+              <MultiSelectOption
+                key={position}
+                checked={formData.positionFilter.includes(position)}
+                onCheckedChange={() => {
+                  if (!formData.positionFilter.includes(position)) {
+                    setFormData({positionFilter: [...formData.positionFilter, position]})
+                  } else {
+                    setFormData({positionFilter: formData.positionFilter.filter(pos => pos !== position)})
+                  }
+                }}
+              >
+                {position}
+              </MultiSelectOption>
             ))}
-          </select>
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={formData.currency}
-            onChange={(e) => setFormData({currency: e.target.value})}
-          >
-            <option value="">Todas las monedas</option>
+          </MultiSelect>
+          <MultiSelect title="Moneda">
             {currencies.map((currency) => (
-              <option key={currency}>{currency}</option>
+              <MultiSelectOption
+                key={currency}
+                checked={formData.currencyFilter.includes(currency)}
+                onCheckedChange={() => {
+                  if (!formData.currencyFilter.includes(currency)) {
+                    setFormData({currencyFilter: [...formData.currencyFilter, currency]})
+                  } else {
+                    setFormData({currencyFilter: formData.currencyFilter.filter(curr => curr !== currency)})
+                  }
+                }}
+              >
+                {currency}
+              </MultiSelectOption>
             ))}
-          </select>
-          <select
-            className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
-            value={formData.seniority}
-            onChange={(e) => setFormData({seniority: e.target.value})}
-          >
-            <option value="">Todos los seniorities</option>
-            {seniorities.map((seniority) => (
-              <option key={seniority}>{seniority}</option>
+          </MultiSelect>
+          <MultiSelect title="Seniority">
+             {seniorities.map((seniority) => (
+              <MultiSelectOption
+                key={seniority}
+                checked={formData.seniorityFilter.includes(seniority)}
+                onCheckedChange={() => {
+                  if (!formData.seniorityFilter.includes(seniority)) {
+                    setFormData({seniorityFilter: [...formData.seniorityFilter, seniority]})
+                  } else {
+                    setFormData({seniorityFilter: formData.seniorityFilter.filter(sen => sen !== seniority)})
+                  }
+                }}
+              >
+                {seniority}
+              </MultiSelectOption>
             ))}
-          </select>
+          </MultiSelect>
         </div>
         {originalDollarPrice !== dollarPrice && (
           <Label className="flex items-center gap-2" htmlFor="simulate">

--- a/src/app/(home)/page.client.tsx
+++ b/src/app/(home)/page.client.tsx
@@ -130,7 +130,12 @@ export default function HomePageClient({
       <Table className="border">
         <TableCaption>
           Siempre tomá los valores como referencia y no como un absoluto. Un total de{" "}
-          {salaries.reduce((count, salary) => count + salary.count, 0)} salarios reportados.
+          {salaries.reduce((count, salary) => count + salary.count, 0)} salarios reportados. Agregá
+          el tuyo{" "}
+          <a href="https://forms.gle/e11Kce3JBoDBfHWi7" rel="noopener" target="_blank">
+            acá
+          </a>
+          .
         </TableCaption>
         <TableHeader>
           <TableRow>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,13 +13,15 @@ export const metadata: Metadata = {
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
     <html lang="en">
-      <body className="dark container m-auto grid min-h-screen grid-rows-[auto,1fr,auto] bg-background px-4 font-sans antialiased">
-        <header className="text-xl font-bold leading-[4rem]">Salancy</header>
-        <main className="py-8">{children}</main>
-        <footer className="text-center leading-[4rem] opacity-70">
-          © {new Date().getFullYear()} Salancy - Página actualizada al{" "}
-          {new Date().toLocaleString()}
-        </footer>
+      <body className="dark m-0 bg-background">
+        <div className="container grid min-h-screen grid-rows-[auto,1fr,auto] px-4 font-sans antialiased">
+          <header className="text-xl font-bold leading-[4rem]">Salancy</header>
+          <main className="py-8">{children}</main>
+          <footer className="text-center leading-[4rem] opacity-70">
+            © {new Date().getFullYear()} Salancy - Página actualizada al{" "}
+            {new Date().toLocaleString()}
+          </footer>
+        </div>    
       </body>
     </html>
   );

--- a/src/components/ui/multiSelect.tsx
+++ b/src/components/ui/multiSelect.tsx
@@ -12,7 +12,7 @@ const MultiSelect = ({ children, title }: MultiSelectProps) => {
     <DropdownMenu.Root>
       <DropdownMenu.Trigger asChild>
         <button
-          className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background pl-3 pr-1 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
+          className="flex h-10 overflow-y-scroll w-[180px] items-center justify-between rounded-md border border-input bg-background pl-3 pr-1 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
           aria-label="Customise options"
         >
           {title} <ChevronDown className="w-4 h-4" />
@@ -44,7 +44,7 @@ const MultiSelectOption = ({
 }: MultiSelectOptionProps) => {
   return (
     <DropdownMenu.CheckboxItem
-      className="group text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] relative px-[25px] select-none outline-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+      className="group text-[13px] leading-none rounded-[3px] flex items-center h-[35px] relative px-[25px] py-2 select-none outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-zinc-700 data-[highlighted]:text-white "
       checked={checked}
       onCheckedChange={onCheckedChange}
     >

--- a/src/components/ui/multiSelect.tsx
+++ b/src/components/ui/multiSelect.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronDown } from "lucide-react";
+
+type MultiSelectProps = {
+  children: React.ReactNode;
+  title: string;
+};
+
+const MultiSelect = ({ children, title }: MultiSelectProps) => {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          className="flex h-10 w-[180px] items-center justify-between rounded-md border border-input bg-background pl-3 pr-1 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
+          aria-label="Customise options"
+        >
+          {title} <ChevronDown className="w-4 h-4" />
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          className="w-[180px] border-zinc-700 border-[1px] border-solid bg-zinc-900 rounded-md p-[5px] shadow-[0px_10px_38px_-10px_rgba(22,_23,_24,_0.35),_0px_10px_20px_-15px_rgba(22,_23,_24,_0.2)] will-change-[opacity,transform] data-[side=top]:animate-slideDownAndFade data-[side=right]:animate-slideLeftAndFade data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade"
+          sideOffset={5}
+          align="start"
+        >
+          {children}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};
+
+type MultiSelectOptionProps = {
+  checked: boolean;
+  onCheckedChange: () => void;
+  children: React.ReactNode;
+};
+
+const MultiSelectOption = ({
+  checked,
+  onCheckedChange,
+  children,
+}: MultiSelectOptionProps) => {
+  return (
+    <DropdownMenu.CheckboxItem
+      className="group text-[13px] leading-none text-violet11 rounded-[3px] flex items-center h-[25px] relative px-[25px] select-none outline-none data-[disabled]:text-mauve8 data-[disabled]:pointer-events-none data-[highlighted]:bg-violet9 data-[highlighted]:text-violet1"
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+    >
+      <DropdownMenu.ItemIndicator className="absolute left-0 w-[25px] inline-flex items-center justify-center">
+        <Check className="w-4 h-4" />
+      </DropdownMenu.ItemIndicator>
+      {children}
+    </DropdownMenu.CheckboxItem>
+  );
+};
+
+export { MultiSelect, MultiSelectOption };


### PR DESCRIPTION
# Reemplazo de select por multiselects

Este PR agrega la funcionalidad de filtrar por varios valores al mismo tiempo, permitiendo así, por ejemplo, comparar salarios de distintas posiciones dentro de una misma área. 

Teniendo en cuenta que la función de selección múltiple nativa de HTML es visualmente poco estética y no se condice con la UI del resto de la aplicación, se agrega un nuevo componente utilizando como base [el componente DropdownMenu de RadixUI](https://www.radix-ui.com/primitives/docs/components/dropdown-menu).


### Estado previo de los filtros
<img width="228" alt="Screenshot 2024-01-16 at 18 51 16" src="https://github.com/goncy/salancy/assets/50848833/d0de69c3-07e0-4a71-88a6-e2a5fb67dc95">

### Estado actual de los filtros
<img width="193" alt="Screenshot 2024-01-16 at 19 20 05" src="https://github.com/goncy/salancy/assets/50848833/35cdc8ae-14f1-4656-94fd-5b8fd40f3bbb">
